### PR TITLE
[Feature] Add privacy message about IP beeing send to hcaptcha.com.

### DIFF
--- a/hcaptcha.php
+++ b/hcaptcha.php
@@ -34,6 +34,24 @@ class PlgCaptchaHcaptcha extends CMSPlugin
 	protected $autoloadLanguage = true;
 
 	/**
+	 * Reports the privacy related capabilities for this plugin to site administrators.
+	 *
+	 * @return  array
+	 *
+	 * @since   1.0.0
+	 */
+	public function onPrivacyCollectAdminCapabilities()
+	{
+		$this->loadLanguage();
+
+		return array(
+			JText::_('PLG_CAPTCHA_HCAPTCHA') => array(
+				JText::_('PLG_CAPTCHA_HCAPTCHA_PRIVACY_CAPABILITY_IP_ADDRESS'),
+			)
+		);
+	}
+	
+	/**
 	 * Initialise the captcha
 	 *
 	 * @return  boolean    True on success, false otherwise

--- a/language/en-GB/en-GB.plg_captcha_hcaptcha.ini
+++ b/language/en-GB/en-GB.plg_captcha_hcaptcha.ini
@@ -22,6 +22,11 @@ PLG_HCAPTCHA_SIZE_DESC="Select compact for a smaller footprint"
 PLG_HCAPTCHA_SIZE_NORMAL="Normal"
 PLG_HCAPTCHA_SIZE_COMPACT="Compact"
 
+Privacy
+PLG_CAPTCHA_HCAPTCHA_PRIVACY_CAPABILITY_IP_ADDRESS=""
+
+PLG_RECAPTCHA_PRIVACY_CAPABILITY_IP_ADDRESS="The reCAPTCHA plugin integrates with hcaptcha's CAPTCHA system as a spam protection service. As part of this service, the IP address of the user answering the captcha challenge is transmitted to hcaptcha.com."
+
 ; Error messages
 PLG_HCAPTCHA_ERROR_NO_PUBLIC_KEY="Public Key (Site Key) is missing"
 PLG_HCAPTCHA_ERROR_NO_PRIVATE_KEY="Private Key (Secret Key) is missing"


### PR DESCRIPTION
This implements the 3.9 privacy feature to tell the site owner about the IP is beeing shared with hcaptcha.com.