### PR TITLE
Language strings not compatible withg J4.4 or 5.0

### DIFF
--- a/joomla4/language/en-GB/plg_captcha_hcaptcha.ini
+++ b/joomla4/language/en-GB/plg_captcha_hcaptcha.ini
@@ -4,12 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_HCAPTCHA="CAPTCHA - hCaptcha"
-PLG_CAPTCHA_HCAPTCHA_XML_DESCRIPTION="<p>A simple CAPTCHA Plugin to protect against SPAM using hCaptcha.com</p>
-<ul>
-<li>Author: Peter Martin, <a href=\"https://data2site.com/\" target=\"_blank\">https://data2site.com/</a></li>
-<li>This plugin uses the CAPTCHA service of: <a href=\"https://www.hcaptcha.com/\" target=\"_blank\">https://www.hcaptcha.com/</a></li>
-<li>Bug reports & additions: <a href=\"https://github.com/pe7er/hcaptcha\" target=\"_blank\">https://github.com/pe7er/hcaptcha</a></li>
-</ul>"
+PLG_CAPTCHA_HCAPTCHA_XML_DESCRIPTION="<p>A simple CAPTCHA Plugin to protect against SPAM using hCaptcha.com</p><ul><li>Author: Peter Martin, <a href=\"https://data2site.com/\" target=\"_blank\">https://data2site.com/</a></li><li>This plugin uses the CAPTCHA service of: <a href=\"https://www.hcaptcha.com/\" target=\"_blank\">https://www.hcaptcha.com/</a></li><li>Bug reports & additions: <a href=\"https://github.com/pe7er/hcaptcha\" target=\"_blank\">https://github.com/pe7er/hcaptcha</a></li></ul>"
 
 ; Params
 PLG_CAPTCHA_HCAPTCHA_PUBLIC_KEY="Site Key"

--- a/joomla4/language/en-GB/plg_captcha_hcaptcha.sys.ini
+++ b/joomla4/language/en-GB/plg_captcha_hcaptcha.sys.ini
@@ -4,9 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_CAPTCHA_HCAPTCHA="CAPTCHA - hCaptcha"
-PLG_CAPTCHA_HCAPTCHA_XML_DESCRIPTION="<p>A simple CAPTCHA Plugin to protect against SPAM using hCaptcha.com</p>
-<ul>
-<li>Author: Peter Martin, <a href=\"https://data2site.com/\" target=\"_blank\">https://data2site.com/</a></li>
-<li>This plugin uses the CAPTCHA service of: <a href=\"https://www.hcaptcha.com/\" target=\"_blank\">https://www.hcaptcha.com/</a></li>
-<li>Bug reports & additions: <a href=\"https://github.com/pe7er/hcaptcha\" target=\"_blank\">https://github.com/pe7er/hcaptcha</a></li>
-</ul>"
+PLG_CAPTCHA_HCAPTCHA_XML_DESCRIPTION="<p>A simple CAPTCHA Plugin to protect against SPAM using hCaptcha.com</p><ul><li>Author: Peter Martin, <a href=\"https://data2site.com/\" target=\"_blank\">https://data2site.com/</a></li><li>This plugin uses the CAPTCHA service of: <a href=\"https://www.hcaptcha.com/\" target=\"_blank\">https://www.hcaptcha.com/</a></li><li>Bug reports & additions: <a href=\"https://github.com/pe7er/hcaptcha\" target=\"_blank\">https://github.com/pe7er/hcaptcha</a></li></ul>"


### PR DESCRIPTION
Due to a recent security change in Joomla it is no longer possible to have language strings split across several lines. This PR resolves that for the en-GB language