### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ has been configured properly and works correctly.
 If you use CSP headers, please add the following to your configuration:
 ```txt
 script-src should include https://hcaptcha.com https://.hcaptcha.com
-frame-src should include https://hcaptcha.com https://.hcaptcha.com
+frame-src should include https://hcaptcha.com https://*.hcaptcha.com
 style-src should include https://hcaptcha.com https://*.hcaptcha.com
 ```
 


### PR DESCRIPTION
Hi Super Joomlers,

Its seems that the Content Security Policy rule regarding frame-src doesn't seem to work for me without the https://*.hcaptcha.com  see the extra ``` * ``` at least for Firefox it did not seem to work as expected. But with the * before the domain it works. Just a feedback. Not trying to be the "smart guy". Just a Super Joomler like you.