### PR TITLE
[j4x-j5x] Improve Security when verifying user response

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ has been configured properly and works correctly.
 ## Content-Security-Policy Settings
 If you use CSP headers, please add the following to your configuration:
 ```txt
-script-src should include https://hcaptcha.com https://.hcaptcha.com
+script-src should include https://hcaptcha.com https://*.hcaptcha.com
 frame-src should include https://hcaptcha.com https://*.hcaptcha.com
 style-src should include https://hcaptcha.com https://*.hcaptcha.com
+connect-src should include https://hcaptcha.com https://*.hcaptcha.com
 ```
 
 ## Translations

--- a/joomla4/hcaptcha.php
+++ b/joomla4/hcaptcha.php
@@ -122,7 +122,7 @@ class PlgCaptchaHcaptcha extends CMSPlugin
         $input = Factory::getApplication()->input;
         $privateKey = $this->params->get('privateKey');
         $remoteIp = IpHelper::getIp();
-        $hCaptchaResponse = $code ?? $input->get('h-captcha-response', '', 'cmd');
+        $hCaptchaResponse = $input->get('h-captcha-response', ($code ?? ''), 'cmd');
 
         // Check for Private Key
         if (empty($privateKey)) {
@@ -156,10 +156,13 @@ class PlgCaptchaHcaptcha extends CMSPlugin
     private function getResponse(string $privateKey, string $remoteIp, string $hCaptchaResponse)
     {
         try {
-            $verifyResponse = HttpFactory::getHttp()->get(
-                'https://hcaptcha.com/siteverify?secret=' . $privateKey .
-                '&response=' . $hCaptchaResponse .
-                '&remoteip=' . $remoteIp
+            $verifyResponse = $verifyResponse = HttpFactory::getHttp()->post(
+                'https://hcaptcha.com/siteverify',
+                http_build_query([
+                    'secret'   => $privateKey,
+                    'response' => $hCaptchaResponse,
+                    'remoteip' => $remoteIp
+                ])
             );
         } catch (RuntimeException $e) {
             throw new \RuntimeException(Text::_('PLG_CAPTCHA_HCAPTCHA_ERROR_CANT_CONNECT_TO_HCAPTCHA_SERVERS'));


### PR DESCRIPTION
Just wanted to contribute to add a little more "secure" implementation not sending the secretkey in a GET request, but rather using POST as recommended by the official hcaptcha web site https://docs.hcaptcha.com/#verify-the-user-response-server-side